### PR TITLE
Update DockerfileTGWUI so GPTQ clone, build and install complete smoo…

### DIFF
--- a/tgwui/DockerfileTGWUI
+++ b/tgwui/DockerfileTGWUI
@@ -32,10 +32,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     chmod +x /app/scripts/build_extensions.sh && . /app/scripts/build_extensions.sh
 
 ## Clone default GPTQ
-RUN git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda /app/repositories/GPTQ-for-LLaMa
+RUN git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git
 ## Build and install default GPTQ ('quant_cuda')
 ARG TORCH_CUDA_ARCH_LIST="6.1;7.0;7.5;8.0;8.6+PTX"
-RUN cd /app/repositories/GPTQ-for-LLaMa/ && python3 setup_cuda.py install
+RUN cd GPTQ-for-LLaMa/ && python3 setup_cuda.py install
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 AS base
 # Runtime pre-reqs


### PR DESCRIPTION
…thly

As the title suggests the build process kept hanging on the cloning of GPTQ-for-LLaMa.git. After playing around in the "DockerfileTGWUI" I found the git clone command asks for a specific branch. Apparently the branch it asks for, is the only branch on that github page.

After fixing that it was unable to install GPTQ because the directory path is incorrect. The git clone command clones the repository in the folder it's run at but the install command starts with `cd /app/repositories/GPTQ-for-LLaMa/` which is unnecessary.